### PR TITLE
Fix for values with colons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Simple statsd server for local development",
   "main": "statsd_logger.js",
   "scripts": {

--- a/statsd_logger.js
+++ b/statsd_logger.js
@@ -21,6 +21,7 @@ module.exports = function (options) {
       .split('\n')
       .forEach(function (metric) {
         var parts = metric.split(':')
+        parts = [parts.shift(), parts.join(':')]
         logger.log('StatsD Metric: ' + parts[0].blue + ' ' + parts[1].green)
       })
   })

--- a/test.js
+++ b/test.js
@@ -78,3 +78,18 @@ test('server message events - multiple messages', function (t) {
   })
   emitter.emit('message', 'gorets:1|c\ngorets:1|c')
 })
+
+test('server message events - colons within gauge', function (t) {
+  t.plan(1)
+  var emitter = new events.EventEmitter()
+  emitter.bind = function () {}
+  createLogger({
+    server: emitter,
+    logger: {
+      log: function (msg) {
+        t.equal(msg, 'StatsD Metric: ' + 'foo'.blue + ' ' + 'bar:baz|c'.green)
+      }
+    }
+  })
+  emitter.emit('message', 'foo:bar:baz|c')
+})


### PR DESCRIPTION
Ensure the message is split on `:` only once, fixing cases where the value portion of the stat may contain colons.